### PR TITLE
Check only kubectl tool version - not the server version

### DIFF
--- a/images/linux/scripts/tests/Tools.Tests.ps1
+++ b/images/linux/scripts/tests/Tools.Tests.ps1
@@ -284,7 +284,7 @@ Describe "Kubernetes tools" {
     }
 
     It "kubectl" {
-        "kubectl version" | Should -MatchCommandOutput "Client Version: v"
+        "kubectl version --client" | Should -MatchCommandOutput "Client Version: v"
     }
 
     It "helm" {


### PR DESCRIPTION

# Description
When reading the error message in https://github.com/actions/runner-images/issues/8094, it is clearly fixed in https://github.com/actions/runner-images/pull/8098. However, we still do try to connect to a server endpoint. It's not a bug but not nice either.

By using `--client` we no longer get `The connection to the server localhost:8080 was refused - did you specify the right host or port?`. See https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#version for more details

#### Related issue:

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
